### PR TITLE
Disable cook button without radio click, add clear button functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,24 +9,31 @@
       <button class="recipe-button">ADD A RECIPE</button>
     </section>
     <section class="main-section">
-      <div>
-        <h1>What are you looking for?</h1>
+      <div id="form-box">
+        <h1>What are you looking for?<span class="required">*</span></h1>
         <form class="meal-form">
-          <input type="radio" id="sides" name="dish" value="sides">
+          <input type="radio" id="sides" name="dish" value="sides" onclick="activateCook()">
           <label for="side">Side</label><br>
-          <input type="radio" id="mains" name="dish" value="mains">
+          <input type="radio" id="mains" name="dish" value="mains" onclick="activateCook()">
           <label for="side">Main Dish</label><br>
-          <input type="radio" id="desserts" name="dish" value="desserts">
+          <input type="radio" id="desserts" name="dish" value="desserts" onclick="activateCook()">
           <label for="side">Dessert</label><br>
-          <input type="radio" id="entire-meal" name="dish" value="entire-meal">
+          <input type="radio" id="entire-meal" name="dish" value="entire-meal" onclick="activateCook()">
           <label for="side">Entire Meal</label><br>
           <button class="lets-cook-button">LET'S COOK!</button>
         </form>
       </div>
-      <div>
-        <img class="" id="pot" src="assets/cookpot.svg">
-        <p class ="hidden you-should-make">You should make:</p>
-        <h1 class="output"></h1>
+      <div id="display-box">
+        <div id="you-should-para">
+          <p class ="hidden you-should-make">You should make:</p>
+        </div>
+        <div id="meal-display">
+          <img class="" id="pot" src="assets/cookpot.svg">
+          <h1 class="output hidden"></h1>
+        </div>
+        <div id="clear-container">
+          <button class="clear hidden">CLEAR</button>
+        </div>
       </div>
     </section>
   </body>

--- a/main.js
+++ b/main.js
@@ -42,8 +42,27 @@ var output = document.querySelector(".output");
 var letsCookButton = document.querySelector(".lets-cook-button");
 var cookPot = document.querySelector("#pot");
 var youShouldMake = document.querySelector(".you-should-make");
+var clearButton = document.querySelector(".clear");
+letsCookButton.disabled = true;
 
-letsCookButton.addEventListener("click", findRadioInput);
+letsCookButton.addEventListener("click", displayMealIdea);
+
+clearButton.addEventListener("click", clearFoodIdea);
+
+function activateCook() {
+  letsCookButton.disabled = false;
+}
+
+function clearFoodIdea() {
+  clearButton.classList.add("hidden");
+  youShouldMake.classList.add("hidden");
+  output.classList.add("hidden");
+  cookPot.classList.remove("hidden");
+}
+
+function showButton() {
+  clearButton.classList.remove("hidden");
+}
 
 function insertText(text) {
   output.innerText = text;
@@ -58,6 +77,7 @@ function getRandom(list) {
 function changeView() {
   cookPot.classList.add("hidden");
   youShouldMake.classList.remove("hidden");
+  output.classList.remove("hidden");
 }
 
 function randomEntireMeal() {
@@ -68,7 +88,7 @@ function randomEntireMeal() {
   insertText(text);
 }
 
-function findRadioInput() {
+function displayMealIdea() {
   event.preventDefault();
   var dishes = document.getElementsByName("dish");
   for (var i = 3; i >= 0; i--) {
@@ -79,4 +99,5 @@ function findRadioInput() {
     }
   }
   changeView();
+  showButton();
 }

--- a/styles.css
+++ b/styles.css
@@ -7,6 +7,10 @@ grey - #95a5a6;
 red - #ee5253
 
 */
+* {
+  border: solid black 1px;
+}
+
 body {
   font-family: 'Roboto', sans-serif;
   background-image: url("assets/burger-friends.jpg");
@@ -33,15 +37,21 @@ body {
   font-size: 14px;
   padding: 10px;
   border: none;
-  border-radius: 5%;
 }
 
 .main-section {
   margin: 50px 0px;
+  height: 55%;
   display: flex;
   justify-content: space-around;
 }
 
+.clear {
+  color: white;
+  background-color: #95a5a6;
+  padding: 8px 12px;
+
+}
 /* div {
   border: solid black 1px;
   background-color: rgba(225, 225, 225, .9);
@@ -54,26 +64,52 @@ body {
   display: none;
 }
 
-div:nth-child(1) {
+#form-box {
   background-color: rgba(225, 225, 225, .9);
-  padding: 35px;
-  width: 430px;
-  height: 300px;
+  padding: 25px;
+  width: 32%;
   display: flex;
   flex-direction: column;
   align-content: center;
   justify-content: center;
 }
 
-div:nth-child(2) {
+#display-box {
   background-color: rgba(225, 225, 225, .9);
-  padding: 35px;
-  width: 430px;
-  height: 300px;
+  padding: 25px;
+  width: 32%;
+  display: grid;
+  grid-template-rows: 38% 42% 20%;
+}
+
+#you-should-para {
+display: flex;
+justify-content: center;
+align-items: flex-end;
+grid-row-start: 1;
+}
+
+#meal-display {
+  /* width: 100%;
+  height: 70%; */
   display: flex;
-  align-items: center;
-  justify-content: center;
   flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  grid-row-start: 2;
+}
+
+#clear-container {
+  display: flex;
+  justify-content: flex-end;
+  align-items: flex-end;
+  grid-row-start: 3;
+}
+
+.you-should-make {
+  font-weight: 700;
+  font-style: italic;
+  margin: 0px;
 }
 
 input {
@@ -85,7 +121,7 @@ input {
 }
 
 .lets-cook-button {
-  margin: 10px;
+  margin: 12px 5px;
   width: 38%;
   padding: 8px 40px;
   background-color: #0fb9b1;
@@ -93,19 +129,20 @@ input {
   font-size: 12px;
 }
 
-.you-should-make {
-  font-weight: 700;
-  font-style: italic;
-  margin: 5px;
-}
-
 .output {
-  font-size: 36px;
-  margin: 0px;
+  font-size: 32px;
+  margin: 5px;
   text-align: center;
 }
 
 #pot {
   height: 150px;
   width: 150px;
+}
+
+.required {
+  color: #ee5253;
+}
+button {
+  border-radius: 4px
 }


### PR DESCRIPTION
## What is the change?
The "LET'S COOK" button is disabled until a radio button is selected.  There is a "CLEAR" button on the right that resets the 2nd gray box.  The meal suggestion and clear button are hidden and the cookpot icon returns.  This happens upon click of the CLEAR button.

## What does it fix?
N/A

## Is this a fix or a feature?
Feature.

## Where should the reviewer start?
html 12-36
main.js 45-65
css 49-54, 79-94, 97-112

## How should this be tested?
Open index.html to check functionality.